### PR TITLE
Make s3 export more stable

### DIFF
--- a/pkg/common/dto/meta.go
+++ b/pkg/common/dto/meta.go
@@ -2,8 +2,9 @@ package dto
 
 import (
 	"fmt"
-	"github.com/dustin/go-humanize"
 	"strings"
+
+	"github.com/dustin/go-humanize"
 )
 
 const (
@@ -100,7 +101,8 @@ type FileSetPrivateEncryptedFiles struct {
 type PublicFilesIndex map[string]PublicFilesIndexEntry
 
 type PublicFilesIndexEntry struct {
-	SizeBytes int64  `json:"sizeBytes"`
-	MTime     int64  `json:"mTime"`
-	PublicUri string `json:"publicUri"`
+	SizeBytes     int64  `json:"sizeBytes"`
+	MTime         int64  `json:"mTime"`
+	PublicUri     string `json:"publicUri"`
+	IsAbsoluteUrl bool   `json:"isAbsoluteUrl"`
 }

--- a/pkg/frameworks/flowServe/flowServe.go
+++ b/pkg/frameworks/flowServe/flowServe.go
@@ -267,6 +267,8 @@ func extractResourcesFromS3(transferSession *serve.TransferSession, db *sql.DB, 
 
 	var resourceSha1, filename string
 	var filesize uint64
+	var filePath string
+	var fileEntry dto.PublicFilesIndexEntry
 	for rows.Next() {
 		err := rows.Scan(&resourceSha1, &filename, &filesize)
 		if err != nil {
@@ -274,14 +276,9 @@ func extractResourcesFromS3(transferSession *serve.TransferSession, db *sql.DB, 
 		}
 
 		totalSizeBytes += filesize
-		escapedFileName := url.PathEscape(filename)
-		// HACK: this is how it works for Neos / Flow. Probably not all escapes done
-		escapedFileName = strings.ReplaceAll(escapedFileName, "+", "%2B")
-		resourceFilesIndex["Resources/"+resourceSha1[0:1]+"/"+resourceSha1[1:2]+"/"+resourceSha1[2:3]+"/"+resourceSha1[3:4]+"/"+resourceSha1] = dto.PublicFilesIndexEntry{
-			SizeBytes: int64(filesize),
-			MTime:     0,
-			PublicUri: persistentTarget.TargetOptions.BaseUri + resourceSha1 + "/" + escapedFileName,
-		}
+
+		filePath, fileEntry = generateResourcePathForS3(filename, resourceSha1, filesize, persistentTarget)
+		resourceFilesIndex[filePath] = fileEntry
 	}
 	err = rows.Err()
 	if err != nil {
@@ -289,6 +286,21 @@ func extractResourcesFromS3(transferSession *serve.TransferSession, db *sql.DB, 
 	}
 
 	commonServe.WriteResourcesIndex(transferSession, dto.TYPE_PUBLICFILES, FlowResources, resourceFilesIndex, totalSizeBytes)
+}
+
+func generateResourcePathForS3(filename string, resourceSha1 string, filesize uint64, persistentTarget *flowResourceTarget) (string, dto.PublicFilesIndexEntry) {
+	escapedFileName := url.PathEscape(filename)
+	// HACK: this is how it works for Neos / Flow. Probably not all escapes done
+	escapedFileName = strings.ReplaceAll(escapedFileName, "+", "%2B")
+
+	filePath := "Resources/" + resourceSha1[0:1] + "/" + resourceSha1[1:2] + "/" + resourceSha1[2:3] + "/" + resourceSha1[3:4] + "/" + resourceSha1
+	fileEntry := dto.PublicFilesIndexEntry{
+		SizeBytes: int64(filesize),
+		MTime:     0,
+		PublicUri: persistentTarget.TargetOptions.BaseUri + resourceSha1 + "/" + escapedFileName,
+	}
+
+	return filePath, fileEntry
 }
 
 func extractResourcesFromFolderSkippingThumbnails(transferSession *serve.TransferSession, db *sql.DB, persistentTarget *flowResourceTarget, whereClauseForTables map[string]string) {

--- a/pkg/frameworks/flowServe/flowServe.go
+++ b/pkg/frameworks/flowServe/flowServe.go
@@ -93,7 +93,10 @@ type flowResourceTarget struct {
 		// f.e. prod-neos-cdn
 		Bucket string `yaml:"bucket"`
 		// f.e. resources/ - see BaseUri
-		KeyPrefix string `yaml:"keyPrefix"`
+		KeyPrefix              string `yaml:"keyPrefix"`
+		PersistentResourceUris struct {
+			Pattern string `yaml:"pattern"`
+		} `yaml:"persistentResourceUris"`
 	} `yaml:"targetOptions"`
 }
 
@@ -267,8 +270,6 @@ func extractResourcesFromS3(transferSession *serve.TransferSession, db *sql.DB, 
 
 	var resourceSha1, filename string
 	var filesize uint64
-	var filePath string
-	var fileEntry dto.PublicFilesIndexEntry
 	for rows.Next() {
 		err := rows.Scan(&resourceSha1, &filename, &filesize)
 		if err != nil {
@@ -276,9 +277,12 @@ func extractResourcesFromS3(transferSession *serve.TransferSession, db *sql.DB, 
 		}
 
 		totalSizeBytes += filesize
-
-		filePath, fileEntry = generateResourcePathForS3(filename, resourceSha1, filesize, persistentTarget)
-		resourceFilesIndex[filePath] = fileEntry
+		resourceFilesIndex["Resources/"+resourceSha1[0:1]+"/"+resourceSha1[1:2]+"/"+resourceSha1[2:3]+"/"+resourceSha1[3:4]+"/"+resourceSha1] = dto.PublicFilesIndexEntry{
+			SizeBytes:     int64(filesize),
+			MTime:         0,
+			PublicUri:     generateS3ResourcePublicPath(persistentTarget, resourceSha1, filename),
+			IsAbsoluteUrl: true,
+		}
 	}
 	err = rows.Err()
 	if err != nil {
@@ -288,19 +292,24 @@ func extractResourcesFromS3(transferSession *serve.TransferSession, db *sql.DB, 
 	commonServe.WriteResourcesIndex(transferSession, dto.TYPE_PUBLICFILES, FlowResources, resourceFilesIndex, totalSizeBytes)
 }
 
-func generateResourcePathForS3(filename string, resourceSha1 string, filesize uint64, persistentTarget *flowResourceTarget) (string, dto.PublicFilesIndexEntry) {
-	escapedFileName := url.PathEscape(filename)
-	// HACK: this is how it works for Neos / Flow. Probably not all escapes done
-	escapedFileName = strings.ReplaceAll(escapedFileName, "+", "%2B")
-
-	filePath := "Resources/" + resourceSha1[0:1] + "/" + resourceSha1[1:2] + "/" + resourceSha1[2:3] + "/" + resourceSha1[3:4] + "/" + resourceSha1
-	fileEntry := dto.PublicFilesIndexEntry{
-		SizeBytes: int64(filesize),
-		MTime:     0,
-		PublicUri: persistentTarget.TargetOptions.BaseUri + resourceSha1 + "/" + escapedFileName,
+// generateS3ResourcePublicPath replicates S3Target::getPublicPersistentResourceUri
+// https://github.com/flownative/flow-aws-s3/blob/main/Classes/S3Target.php#L465
+func generateS3ResourcePublicPath(persistentTarget *flowResourceTarget, resourceSha1 string, filename string) string {
+	if pattern := persistentTarget.TargetOptions.PersistentResourceUris.Pattern; pattern != "" {
+		return strings.NewReplacer(
+			"{baseUri}", persistentTarget.TargetOptions.BaseUri,
+			"{bucketName}", persistentTarget.TargetOptions.Bucket,
+			"{keyPrefix}", persistentTarget.TargetOptions.KeyPrefix,
+			"{sha1}", resourceSha1,
+			"{filename}", filename,
+			"{fileExtension}", strings.TrimPrefix(filepath.Ext(filename), "."),
+		).Replace(pattern)
 	}
 
-	return filePath, fileEntry
+	// HACK: this is how it works for Neos / Flow. Probably not all escapes done
+	escapedFileName := url.PathEscape(filename)
+	escapedFileName = strings.ReplaceAll(escapedFileName, "+", "%2B")
+	return persistentTarget.TargetOptions.BaseUri + resourceSha1 + "/" + escapedFileName
 }
 
 func extractResourcesFromFolderSkippingThumbnails(transferSession *serve.TransferSession, db *sql.DB, persistentTarget *flowResourceTarget, whereClauseForTables map[string]string) {
@@ -337,9 +346,10 @@ func extractResourcesFromFolderSkippingThumbnails(transferSession *serve.Transfe
 		escapedFileName = strings.ReplaceAll(escapedFileName, "+", "%2B")
 		adjustedBaseUri := strings.TrimPrefix(persistentTarget.TargetOptions.BaseUri, "_Resources/")
 		resourceFilesIndex["Resources/"+resourceSha1[0:1]+"/"+resourceSha1[1:2]+"/"+resourceSha1[2:3]+"/"+resourceSha1[3:4]+"/"+resourceSha1] = dto.PublicFilesIndexEntry{
-			SizeBytes: int64(filesize),
-			MTime:     0,
-			PublicUri: "<BASE>/" + adjustedBaseUri + resourceSha1[0:1] + "/" + resourceSha1[1:2] + "/" + resourceSha1[2:3] + "/" + resourceSha1[3:4] + "/" + resourceSha1 + "/" + escapedFileName,
+			SizeBytes:     int64(filesize),
+			MTime:         0,
+			PublicUri:     adjustedBaseUri + resourceSha1[0:1] + "/" + resourceSha1[1:2] + "/" + resourceSha1[2:3] + "/" + resourceSha1[3:4] + "/" + resourceSha1 + "/" + escapedFileName,
+			IsAbsoluteUrl: false,
 		}
 	}
 	err = rows.Err()
@@ -390,9 +400,10 @@ func extractAllResourcesFromFolder(transferSession *serve.TransferSession, persi
 
 			totalSizeBytes += uint64(realFileInfo.Size())
 			resourceFilesIndex["Resources/"+resourceSha1[0:1]+"/"+resourceSha1[1:2]+"/"+resourceSha1[2:3]+"/"+resourceSha1[3:4]+"/"+resourceSha1] = dto.PublicFilesIndexEntry{
-				SizeBytes: int64(realFileInfo.Size()),
-				MTime:     realFileInfo.ModTime().Unix(),
-				PublicUri: "<BASE>/" + publicUri,
+				SizeBytes:     int64(realFileInfo.Size()),
+				MTime:         realFileInfo.ModTime().Unix(),
+				PublicUri:     publicUri,
+				IsAbsoluteUrl: false,
 			}
 			return nil
 		})

--- a/pkg/frameworks/flowServe/flowServer_test.go
+++ b/pkg/frameworks/flowServe/flowServer_test.go
@@ -2,27 +2,63 @@ package flowServe
 
 import "testing"
 
-func TestGenerateResourcePathForS3(t *testing.T) {
-	persistentTargetConfig := flowResourceTarget{
-		Target: "Flownative\\Aws\\S3\\S3Target",
-		TargetOptions: struct {
-			Path      string `yaml:"path"`
-			BaseUri   string `yaml:"baseUri"`
-			Bucket    string `yaml:"bucket"`
-			KeyPrefix string `yaml:"keyPrefix"`
-		}{Path: "", BaseUri: "https://cdn.vendor.com/r/", Bucket: "project-prod-cdn-export", KeyPrefix: "r/"},
-	}
+type generateS3ResourcesPathTest struct {
+	filename            string
+	resourceSha1        string
+	targetConfiguration flowResourceTarget
+	wantedPublicUri     string
+}
 
-	path, entry := generateResourcePathForS3(
-		"sample-image.jpg", "3233621371f429bfc0e36b47c12b116b688055bf", 256, &persistentTargetConfig)
+var generateS3ResourcesPathTests = []generateS3ResourcesPathTest{
+	{
+		filename:     "sample-image.jpg",
+		resourceSha1: "3233621371f429bfc0e36b47c12b116b688055bf",
+		targetConfiguration: flowResourceTarget{
+			Target: "Flownative\\Aws\\S3\\S3Target",
+			TargetOptions: struct {
+				Path                   string `yaml:"path"`
+				BaseUri                string `yaml:"baseUri"`
+				Bucket                 string `yaml:"bucket"`
+				KeyPrefix              string `yaml:"keyPrefix"`
+				PersistentResourceUris struct {
+					Pattern string `yaml:"pattern"`
+				} `yaml:"persistentResourceUris"`
+			}{Path: "", BaseUri: "https://cdn.vendor.com/r/", Bucket: "project-prod-cdn-export", KeyPrefix: "r/"},
+		},
+		wantedPublicUri: "https://cdn.vendor.com/r/3233621371f429bfc0e36b47c12b116b688055bf/sample-image.jpg",
+	},
+	{
+		filename:     "sample-image.jpg",
+		resourceSha1: "2b5a802db2bc2f3e5eb7f7d9720201abc5cc511a",
+		targetConfiguration: flowResourceTarget{
+			Target: "Flownative\\Aws\\S3\\S3Target",
+			TargetOptions: struct {
+				Path                   string `yaml:"path"`
+				BaseUri                string `yaml:"baseUri"`
+				Bucket                 string `yaml:"bucket"`
+				KeyPrefix              string `yaml:"keyPrefix"`
+				PersistentResourceUris struct {
+					Pattern string `yaml:"pattern"`
+				} `yaml:"persistentResourceUris"`
+			}{
+				Path:      "",
+				BaseUri:   "https://fsn1.your-objectstorage.com",
+				Bucket:    "project-prod-web-assets",
+				KeyPrefix: "project/site",
+				PersistentResourceUris: struct {
+					Pattern string `yaml:"pattern"`
+				}{Pattern: "/web-assets/{keyPrefix}/{sha1}/{filename}"},
+			},
+		},
+		wantedPublicUri: "/web-assets/project/site/2b5a802db2bc2f3e5eb7f7d9720201abc5cc511a/sample-image.jpg",
+	},
+}
 
-	wantedPath := "Resources/3/2/3/3/3233621371f429bfc0e36b47c12b116b688055bf"
-	wantedPublicUri := "https://cdn.vendor.com/r/3233621371f429bfc0e36b47c12b116b688055bf/sample-image.jpg"
-
-	if wantedPath != path {
-		t.Errorf("path %q does not match %q", path, wantedPath)
-	}
-	if entry.PublicUri != wantedPublicUri {
-		t.Errorf("publicUri %q does not match %q", entry.PublicUri, "TODO")
+func TestGenerateS3ResourcesPaths(t *testing.T) {
+	for _, tt := range generateS3ResourcesPathTests {
+		path := generateS3ResourcePublicPath(&tt.targetConfiguration, tt.resourceSha1, tt.filename)
+		if path != tt.wantedPublicUri {
+			t.Errorf("publicUri %q does not match %q", path, tt.wantedPublicUri)
+		}
 	}
 }

--- a/pkg/frameworks/flowServe/flowServer_test.go
+++ b/pkg/frameworks/flowServe/flowServer_test.go
@@ -1,0 +1,28 @@
+package flowServe
+
+import "testing"
+
+func TestGenerateResourcePathForS3(t *testing.T) {
+	persistentTargetConfig := flowResourceTarget{
+		Target: "Flownative\\Aws\\S3\\S3Target",
+		TargetOptions: struct {
+			Path      string `yaml:"path"`
+			BaseUri   string `yaml:"baseUri"`
+			Bucket    string `yaml:"bucket"`
+			KeyPrefix string `yaml:"keyPrefix"`
+		}{Path: "", BaseUri: "https://cdn.vendor.com/r/", Bucket: "project-prod-cdn-export", KeyPrefix: "r/"},
+	}
+
+	path, entry := generateResourcePathForS3(
+		"sample-image.jpg", "3233621371f429bfc0e36b47c12b116b688055bf", 256, &persistentTargetConfig)
+
+	wantedPath := "Resources/3/2/3/3/3233621371f429bfc0e36b47c12b116b688055bf"
+	wantedPublicUri := "https://cdn.vendor.com/r/3233621371f429bfc0e36b47c12b116b688055bf/sample-image.jpg"
+
+	if wantedPath != path {
+		t.Errorf("path %q does not match %q", path, wantedPath)
+	}
+	if entry.PublicUri != wantedPublicUri {
+		t.Errorf("publicUri %q does not match %q", entry.PublicUri, "TODO")
+	}
+}

--- a/pkg/receive/cmd/receive-cmd.go
+++ b/pkg/receive/cmd/receive-cmd.go
@@ -6,6 +6,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
 	"github.com/pterm/pterm"
 	"github.com/repeale/fp-go"
 	"github.com/sandstorm/synco/v2/pkg/common/config"
@@ -15,12 +22,6 @@ import (
 	"github.com/sandstorm/synco/v2/pkg/ui/multiselect"
 	"github.com/sandstorm/synco/v2/pkg/ui/textinput"
 	"github.com/spf13/cobra"
-	"io"
-	"net/url"
-	"os"
-	"path/filepath"
-	"strings"
-	"time"
 )
 
 var interactive bool
@@ -264,8 +265,10 @@ func downloadPublicFiles(receiveSession *receive.ReceiveSession, fileSet *dto.Fi
 
 		// the default base URL is the transfer session, which is by convention placed INSIDE the web root.
 		// so we need to go one level up when finding <BASE>
-		// TODO: this is a bit brittle - but for now it works.
-		err = receiveSession.DumpFileWithProgressBar(strings.ReplaceAll(fileDefinition.PublicUri, "<BASE>", ".."), fileName, progress)
+
+		// TODO: this is a bit brittle - but for now it works
+		// TODO keep BASE replace, when starting with / (without base) => use HOST_NAME before.
+		err = receiveSession.DumpFileWithProgressBar(fileName, fileDefinition, progress)
 		if err != nil {
 			pterm.Error.Printfln("error on downloading %s to %s: %w - continuing with next file", fileDefinition.PublicUri, fileName, err)
 			// continue with next iteration

--- a/pkg/receive/receive-session.go
+++ b/pkg/receive/receive-session.go
@@ -6,11 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"errors"
-	"filippo.io/age"
 	"fmt"
-	"github.com/pterm/pterm"
-	"github.com/sandstorm/synco/v2/pkg/common/dto"
-	"github.com/sandstorm/synco/v2/pkg/ui/boolselect"
 	"io"
 	"net"
 	"net/http"
@@ -20,6 +16,11 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"filippo.io/age"
+	"github.com/pterm/pterm"
+	"github.com/sandstorm/synco/v2/pkg/common/dto"
+	"github.com/sandstorm/synco/v2/pkg/ui/boolselect"
 )
 
 type State string
@@ -219,13 +220,15 @@ func (rs *ReceiveSession) FetchAndDecryptFileWithProgressBar(fileName string) (*
 	return buf, nil
 }
 
-func (rs *ReceiveSession) FetchFileWithProgressBar(fileName string, progress *pterm.ProgressbarPrinter) (*bytes.Buffer, error) {
+func (rs *ReceiveSession) FetchFileWithProgressBar(fileName string, fileDefinition dto.PublicFilesIndexEntry, progress *pterm.ProgressbarPrinter) (*bytes.Buffer, error) {
 	var urlToLoad string
 	var err error
 	if strings.HasPrefix(fileName, "http://") || strings.HasPrefix(fileName, "https://") {
 		urlToLoad = fileName
+	} else if fileDefinition.IsAbsoluteUrl {
+		urlToLoad = strings.ReplaceAll(*rs.baseUrl, "/_Resources", "") + fileDefinition.PublicUri
 	} else {
-		urlToLoad, err = url.JoinPath(*rs.baseUrl, rs.identifier, fileName)
+		urlToLoad, err = url.JoinPath(*rs.baseUrl, strings.ReplaceAll(fileDefinition.PublicUri, "<BASE>", ""))
 		if err != nil {
 			return nil, err
 		}
@@ -303,12 +306,12 @@ func (rs *ReceiveSession) DumpAndDecryptFileWithProgressBar(remoteFileName strin
 	return nil
 }
 
-func (rs *ReceiveSession) DumpFileWithProgressBar(remoteFileName string, localFileName string, progress *pterm.ProgressbarPrinter) error {
-	contents, err := rs.FetchFileWithProgressBar(remoteFileName, progress)
+func (rs *ReceiveSession) DumpFileWithProgressBar(fileName string, fileDefinition dto.PublicFilesIndexEntry, progress *pterm.ProgressbarPrinter) error {
+	contents, err := rs.FetchFileWithProgressBar(fileName, fileDefinition, progress)
 	if err != nil {
 		return err
 	}
-	workdirFilePath := rs.filepathInWorkDir(localFileName)
+	workdirFilePath := rs.filepathInWorkDir(fileName)
 	err = os.MkdirAll(filepath.Dir(workdirFilePath), 0755)
 	if err != nil {
 		return err


### PR DESCRIPTION
Add support for different S3Target configurations. Fix how synco downloads absolute urls and refactored receive path building.

Tested the build on two different Neos installations:
* one using plain local resources
* one using S3Target using pathPatterns

I included the S3-configuration of a third neos installation to ensure that the path building does not brake for when absolute urls (without pathPatterns) are build, but I cant verify if that installation actually works with this build