### PR TITLE
✨ FEATURE: add --version to synco command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	cmd2 "github.com/sandstorm/synco/v2/pkg/receive/cmd"
 	"github.com/sandstorm/synco/v2/pkg/serve/cmd"
 	"github.com/spf13/cobra"
@@ -35,6 +37,17 @@ synco receive http://your-server/abcde password-from-server`,
 	//
 	// 	return nil
 	// },
+}
+
+// SetVersionInfo wires the build-time version metadata (injected via -ldflags, see
+// .goreleaser.yml) into the root command so that "synco --version" reports it.
+// It must be called before Execute().
+func SetVersionInfo(version, commit, date, builtBy string) {
+	rootCmd.Version = version
+	rootCmd.SetVersionTemplate(fmt.Sprintf(
+		"synco {{.Version}}\ncommit: %s\nbuilt at: %s\nbuilt by: %s\n",
+		commit, date, builtBy,
+	))
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/main.go
+++ b/main.go
@@ -7,7 +7,17 @@ import (
 	"os/signal"
 )
 
+// These variables are set at build time via -ldflags by GoReleaser (see .goreleaser.yml).
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+	builtBy = "unknown"
+)
+
 func main() {
+	cmd.SetVersionInfo(version, commit, date, builtBy)
+
 	//kubernetes.KubernetesInit()
 
 	// Fetch user interrupt - WORKAROUND: Somehow, this only works when in main.go - if we move it somewhere else, it will break.


### PR DESCRIPTION
Call `synco --version` to get the synco version printed.

Example from local dev:

`synco --version`
synco v2.3.1
commit: abc1234
built at: 2026-06-18
built by: goreleaser